### PR TITLE
ROS 2ノード自動起動がうまくいかない問題に対する修正

### DIFF
--- a/service/ros2_launch.sh
+++ b/service/ros2_launch.sh
@@ -3,6 +3,7 @@
 SCRIPTDIR=/home/pi/service/
 ENVFILE=/home/pi/ros2_ws/install/local_setup.bash
 
+sudo /usr/sbin/ip link set lo multicast on
 echo "Loading ROS2 Env..."
 source /opt/ros/humble/setup.bash
 source ${ENVFILE}

--- a/service/scramble_auto_robot_ros2.service
+++ b/service/scramble_auto_robot_ros2.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=ROS2 launch
-After=local-fs.target
+After=local-fs.target network-online.target
 ConditionPathExists=/home/pi/service
 
 [Service]
+ExecStartPre=/bin/sleep 5
 ExecStart=/home/pi/service/ros2_launch.sh
 ExecStop=/bin/kill ${MAINPID}
 Restart=on-failure


### PR DESCRIPTION
お世話になっております。TKGの土方です。

READMEに記載の手順でラズパイのセットアップを行った際にROS 2の自動起動がうまく動作しなかったので、修正を行いました。
主な問題と修正は以下の2点です。
1. 自動起動時に以下のエラーが発生する問題(sudo systemctl statusで確認)。
   selected interface "lo" is not multicast-capable: disabling multicast
   →ros2_launch.shにloのマルチキャストを有効にする文を追加
   
2. ノードはエラーなく立ち上がっている(sudo systemctl statusで確認)けれどトピックが生成されない問題。
   →scramble_auto_robot_ros2.serviceにネットワークが有効になるまで待った上で追加で5秒待つ処理を追加

ご確認のほどよろしくおねがいします。